### PR TITLE
Payload API

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -14,6 +14,7 @@ library
       Herp.HttpLogger
       Herp.Logger
       Herp.Logger.LogLevel
+      Herp.Logger.Payload
       Herp.Logger.SentryTransport
       Herp.Logger.StdoutTransport
       Herp.Logger.Transport
@@ -81,6 +82,7 @@ library
     , deepseq
     , exceptions
     , fast-logger
+    , generic-data
     , gitrev
     , hashable
     , herp-util ^>= 0.2

--- a/src/Herp/Logger/LogLevel.hs
+++ b/src/Herp/Logger/LogLevel.hs
@@ -12,6 +12,7 @@ import "aeson"   Data.Aeson                     ( Value(String), ToJSON(..) )
 import "base"    GHC.OverloadedLabels           ( IsLabel(fromLabel) )
 
 -- | https://tools.ietf.org/html/rfc5424#section-6.2.1
+-- https://scrapbox.io/herp-inc/RFC_draft_%E3%83%AD%E3%82%B0%E3%83%AC%E3%83%99%E3%83%AB%E3%81%AB%E3%81%AF_syslog_%E5%BD%A2%E5%BC%8F%E3%82%92%E4%BD%BF%E3%81%86
 data LogLevel
     = Debug -- ^ debug-level messages
     | Informational -- ^ informational messages
@@ -24,6 +25,7 @@ data LogLevel
     deriving stock Eq
     deriving stock Ord
     deriving stock Show
+    deriving stock Bounded
 
 instance ToJSON LogLevel where
     toJSON Emergency     = String "emerg"

--- a/src/Herp/Logger/Payload.hs
+++ b/src/Herp/Logger/Payload.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Herp.Logger.Payload
+  ( Payload(..)
+  , level
+  , message) where
+
+import Data.Aeson
+import Data.Semigroup
+import Data.Monoid
+import Data.String
+import Data.Text (Text)
+import Generic.Data
+import GHC.OverloadedLabels
+import Herp.Logger.LogLevel
+
+data Payload = Payload
+  { payloadLevel :: Max LogLevel
+  , payloadMessage :: Text -- モノイドとして結合するためにあえて別フィールド
+  , payloadObject :: Object
+  }
+  deriving stock Generic
+  deriving (Semigroup, Monoid) via Generically Payload
+
+instance IsLabel k LogLevel => IsLabel k Payload where
+  fromLabel = level (fromLabel @k)
+
+level :: LogLevel -> Payload
+level lvl = mempty { payloadLevel = Max lvl }
+
+message :: Text -> Payload
+message txt = mempty { payloadMessage = txt }
+
+instance IsString Payload where
+  fromString = message . fromString
+
+instance KeyValue Payload where
+  key .= val = mempty { payloadObject = key .= val }


### PR DESCRIPTION
APIを刷新し、以下のような記述ができるようになった。入力がモノイドであるのが要であり、正しい記述を簡潔に書きやすくなる。

* ログレベルは、より強い方を優先する
* メッセージは結合する
* key-valueペア `.=` はunionを取る

```haskell
logM $ mconcat [level Warning, message "hello, world", "key" .= value]
```

蛇足かもしれないが、OverloadedLabelsを使って以下のようにも書ける。

```haskell
logM $ "hello, world" <> #warn
```