### PR TITLE
herp-utilではなくresource-pool-0.3を直に使う

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -85,7 +85,6 @@ library
     , generic-data
     , gitrev
     , hashable
-    , herp-util ^>= 0.2
     , http-conduit
     , lrucaching
     , monad-logger
@@ -95,6 +94,7 @@ library
     , proto3-suite
     , proto3-wire
     , raven-haskell ==0.1.4.*
+    , resource-pool ^>= 0.3
     , rio
     , safe
     , safe-exceptions


### PR DESCRIPTION
herp-utilはあまりメンテナンスされておらず、事実上ThreadPoolはherp-logger専用の機能なので、resource-poolのバージョンアップついでにこちらに移動した。マージされたらherp-utilから古い実装を削除する。herp-utilへの依存をなくすことで、OSSとしてリリースするという目標(どこかに書かれていたが忘れた)に近づく。

一般論として、導入やメンテナンスの面倒を避けるため、社内ライブラリ間の深い依存関係は避けたい。