### PR TITLE
Cleanup

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -79,7 +79,6 @@ library
     , proto3-suite
     , raven-haskell ==0.1.4.*
     , resource-pool ^>= 0.3
-    , rio
     , safe-exceptions
     , stm
     , text

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -12,6 +12,7 @@ module Herp.Logger
     , logIO
     , recordLog
     , urgentLog
+    , Herp.Logger.flush
     -- * Payload
     , Payload
     , P.level
@@ -22,7 +23,6 @@ module Herp.Logger
     ) where
 
 import "base" Prelude hiding (log)
-import "base" Data.List qualified as List
 import "base" Data.Semigroup (Max(..))
 
 #if MIN_VERSION_aeson(2,0,0)
@@ -30,18 +30,17 @@ import Data.Aeson.KeyMap as HashMap
 #else
 import "unordered-containers" Data.HashMap.Strict qualified as HashMap
 #endif
-import "base" Control.Concurrent ( forkIO, killThread, forkFinally )
+import "base" Control.Concurrent ( killThread, forkFinally )
 import "async" Control.Concurrent.Async (async, Async, cancel)
 import "base" Control.Monad (forever, forM, forM_, when)
 import "base" Control.Monad.IO.Class (MonadIO(liftIO))
 import "stm" Control.Concurrent.STM
 import Control.Monad.Logger qualified as ML
 import "base" System.IO (hSetBuffering, BufferMode(..), stdout)
-import "mtl" Control.Monad.Reader (ReaderT, ask, asks, MonadReader)
-import "aeson" Data.Aeson                     ((.=), Object, Value(..))
+import "mtl" Control.Monad.Reader (asks, MonadReader)
+import "aeson" Data.Aeson                     ((.=), Value(..))
 import "aeson" Data.Aeson qualified as A
 import "aeson" Data.Aeson.Encoding qualified as A
-import "aeson" Data.Aeson.Types               (Pair)
 import "bytestring" Data.ByteString.Lazy.Char8 qualified as BC
 import "bytestring" Data.ByteString.Short qualified as BS
 import "fast-logger" System.Log.FastLogger.Date (newTimeCache)
@@ -51,7 +50,6 @@ import "text" Data.Text.Encoding qualified as T
 import Data.UnixTime (formatUnixTime, fromEpochTime)
 import System.PosixCompat.Time (epochTime)
 import "proto3-suite" Proto3.Suite.JSONPB qualified as JSONPB
-import RIO (RIO(..))
 
 import Herp.Logger.Payload           as P
 import Herp.Logger.LogLevel          as X
@@ -63,9 +61,7 @@ import "base" GHC.Generics
 import "safe-exceptions" Control.Exception.Safe qualified as E
 
 
-newtype ThreadPool = ThreadPool
-    { unThreadPool :: Pool (TChan (IO ()), Async ())
-    }
+newtype ThreadPool = ThreadPool (Pool (TChan (IO ()), Async ()))
 
 type ConcurrencyLevel = Int
 
@@ -196,10 +192,10 @@ log' :: Logger -> FormattedTime -> Payload -> IO ()
 log' logger date obj = do
     let Logger { push } = logger
     let extraKey = "extra"
-    let level = getMax $ payloadLevel obj
-    when (checkToLog logger level) $ do
+    let lvl = getMax $ payloadLevel obj
+    when (checkToLog logger lvl) $ do
         push TransportInput
-            { level = level
+            { level = lvl
             , date = BS.toShort date
             , message = payloadMessage obj
             , extra = if HashMap.null $ payloadObject obj then Nothing else Just (extraKey, Object $ payloadObject obj)
@@ -227,7 +223,7 @@ flush = asks toLogger >>= liftIO . loggerFlush
 
 -- logging function for service log
 recordLog :: (MonadIO m, JSONPB.ToJSONPB serviceLog) => Logger -> Text -> serviceLog -> m ()
-recordLog logger message serviceLog = do
+recordLog logger msg serviceLog = do
     let msgLevel = Informational -- datadogはloglevelを要求する
     let Logger {push, timeCache} = logger
     when (checkToLog logger msgLevel) $ do
@@ -242,7 +238,7 @@ recordLog logger message serviceLog = do
         liftIO $ push TransportInput {
               level = msgLevel
             , date = BS.toShort date
-            , message
+            , message = msg
             , extra = Just (serviceLogKey, value)
             }
 
@@ -252,8 +248,8 @@ serviceLogKey = "service"
 runLoggingT :: Logger -> ML.LoggingT IO () -> IO ()
 runLoggingT logger (ML.LoggingT run) = run $ \loc logSrc lv logStr -> do
   let msg = Text.decodeUtf8 $ ML.fromLogStr $ ML.defaultLogStr loc logSrc lv logStr
-  lv <- cnvlv lv
-  logIO logger $ P.level lv <> P.message msg where
+  lv' <- cnvlv lv
+  logIO logger $ P.level lv' <> P.message msg where
     cnvlv ML.LevelDebug = return Debug
     cnvlv ML.LevelInfo = return Informational
     cnvlv ML.LevelWarn = return Warning

--- a/src/Herp/Logger/Payload.hs
+++ b/src/Herp/Logger/Payload.hs
@@ -9,7 +9,6 @@ module Herp.Logger.Payload
 
 import Data.Aeson (Object, KeyValue(..))
 import Data.Semigroup
-import Data.Monoid
 import Data.String
 import Data.Text (Text)
 import Generic.Data

--- a/src/Herp/Logger/SentryTransport.hs
+++ b/src/Herp/Logger/SentryTransport.hs
@@ -6,7 +6,7 @@ module Herp.Logger.SentryTransport
     ) where
 
 import "text" Data.Text (Text, unpack)
-import "aeson" Data.Aeson (Object, Value)
+import "aeson" Data.Aeson (Value)
 import "unordered-containers" Data.HashMap.Strict (HashMap)
 import "raven-haskell" System.Log.Raven (register)
 import "raven-haskell" System.Log.Raven.Types

--- a/src/Herp/Logger/StdoutTransport.hs
+++ b/src/Herp/Logger/StdoutTransport.hs
@@ -12,10 +12,8 @@ import Data.ByteString.Short qualified as SB
 import Data.Text.Encoding qualified as T
 
 #if MIN_VERSION_aeson(2,0,0)
-import Data.Aeson.KeyMap as HashMap
 import "aeson" Data.Aeson.Key (fromText)
 #else
-import Data.HashMap.Strict as HashMap
 import Data.Text
 fromText :: Text -> Text
 fromText = id

--- a/src/Herp/Logger/Transport.hs
+++ b/src/Herp/Logger/Transport.hs
@@ -6,7 +6,7 @@ module Herp.Logger.Transport
     ) where
 
 import "text" Data.Text
-import "aeson" Data.Aeson ( Object, Value )
+import "aeson" Data.Aeson ( Value )
 import "bytestring" Data.ByteString.Short (ShortByteString)
 import Herp.Logger.LogLevel ( LogLevel )
 import GHC.Generics (Generic)


### PR DESCRIPTION
警告の修正と`runLoggingT`のリファクタリング。

特に `toLoggerIO` をエクスポートすることにより、yesodからherp-loggerを呼び出すことが可能になる