### PR TITLE
PayloadにIsListのインスタンスを追加

### DIFF
--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE CPP #-}
 
@@ -170,7 +171,7 @@ new concLevel loggerThresholdLevel transports = do
                 }
 
     let transportToValue tr = A.object ["name" .= name tr, "transport_level" .= threshold tr]
-    logIO logger $ mconcat
+    logIO logger
             [ #info
             , "logger.new"
             , "log_level" .= loggerThresholdLevel
@@ -255,7 +256,8 @@ toLoggerIO :: Logger -> ML.Loc -> ML.LogSource -> ML.LogLevel -> ML.LogStr -> IO
 toLoggerIO logger loc logSrc lv logStr = do
   let msg = Text.decodeUtf8 $ ML.fromLogStr $ ML.defaultLogStr loc logSrc lv logStr
   logIO logger
-    $ P.message msg
-    <> case convertLogLevel lv of
+    [ P.message msg
+    , case convertLogLevel lv of
         Right x -> P.level x
-        Left other -> #warn <> "level" .= other
+        Left other -> [#warn, "level" .= other]
+    ]

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -209,15 +209,16 @@ instance HasLogger Logger where
     toLogger = id
 
 logIO :: MonadIO m => Logger -> Payload -> m ()
-logIO logger@Logger {timeCache} ~msg = do
+logIO logger@Logger {timeCache} msg = do
     date <- liftIO timeCache
     liftIO $ log' logger date msg
-{-# SPECIALIZE logIO :: Logger -> Payload -> IO () #-}
+{-# INLINE logIO #-}
 
 logM :: forall r m. (MonadReader r m, HasLogger r, MonadIO m) => Payload -> m ()
-logM ~msg = do
+logM msg = do
     logger <- asks toLogger
     logIO logger msg
+{-# INLINE logM #-}
 
 flush :: forall r m. (MonadReader r m, HasLogger r, MonadIO m) => m ()
 flush = asks toLogger >>= liftIO . loggerFlush

--- a/src/Herp/Logger/Payload.hs
+++ b/src/Herp/Logger/Payload.hs
@@ -12,6 +12,7 @@ import Data.Semigroup
 import Data.String
 import Data.Text (Text)
 import Generic.Data
+import GHC.Exts
 import GHC.OverloadedLabels
 import Herp.Logger.LogLevel
 
@@ -22,6 +23,11 @@ data Payload = Payload
   }
   deriving stock Generic
   deriving (Semigroup, Monoid) via Generically Payload
+
+instance IsList Payload where
+  type Item Payload = Payload
+  toList = pure
+  fromList = mconcat
 
 instance IsLabel k LogLevel => IsLabel k Payload where
   fromLabel = level (fromLabel @k)


### PR DESCRIPTION
pigeonpostでherp-loggerを使ってみて、ほとんどの箇所で引数をmconcatしていることに気づいたため。

IsListのfromListとtoListに特に則はないため、この定義は合法である