### PR TITLE
`new` takes a `Config` record (fixes #12)

### DIFF
--- a/tests/stdout.hs
+++ b/tests/stdout.hs
@@ -12,7 +12,7 @@ import Herp.Logger.StdoutTransport
 import System.Log.FastLogger.LoggerSet as LS
 
 loggerLevelTest loggerSet transports lv = do
-    logger <- Logger.new 1 lv transports
+    logger <- Logger.newLogger defaultLoggerConfig { logLevel = lv, createTransports = pure transports }
 
     flip runReaderT logger $ do
         logM [ #debug, "debug" ]


### PR DESCRIPTION
newの引数としてレコードを取ることにより、APIの拡張性、安定性、わかりやすさを高めた。さらにデフォルト値として stdoutTransportを作成することにより、fast-loggerをインポートすることなく簡単にロガーを作成できるようにした。