### PR TITLE
defaultLoggerConfigの修正

### DIFF
--- a/tests/stdout.hs
+++ b/tests/stdout.hs
@@ -11,8 +11,8 @@ import Herp.Logger as Logger
 import Herp.Logger.StdoutTransport
 import System.Log.FastLogger.LoggerSet as LS
 
-loggerLevelTest loggerSet transports lv = do
-    logger <- Logger.newLogger defaultLoggerConfig { logLevel = lv, createTransports = pure transports }
+loggerLevelTest config = do
+    logger <- Logger.newLogger config
 
     flip runReaderT logger $ do
         logM [ #debug, "debug" ]
@@ -28,6 +28,7 @@ loggerLevelTest loggerSet transports lv = do
 
 main :: IO ()
 main = bracket (LS.newStdoutLoggerSet 4096) LS.rmLoggerSet $ \loggerSet -> do
-    loggerLevelTest loggerSet [stdoutTransport loggerSet Debug] Debug
-    loggerLevelTest loggerSet [stdoutTransport loggerSet Debug] Informational
-    loggerLevelTest loggerSet [stdoutANSITransport loggerSet Debug] Debug
+    loggerLevelTest defaultLoggerConfig
+    loggerLevelTest defaultLoggerConfig{createTransports = pure [stdoutTransport loggerSet Debug]}
+    loggerLevelTest defaultLoggerConfig{createTransports = pure [stdoutTransport loggerSet Debug], logLevel = Informational}
+    loggerLevelTest defaultLoggerConfig{createTransports = pure [stdoutANSITransport loggerSet Debug]}


### PR DESCRIPTION
`newLogger defaultLoggerConfig`から作成したLoggerに対し、terminalに出力する場合にログの内容が色付きになるよう修正しました。また、テスト用の `stdout.hs` のファイル中にあった `loggerLevelTest` の引数が一部使われていなかったのでその分も修正しました。