### PR TITLE
Improve `runLoggingT`

### DIFF
--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -257,7 +257,7 @@ recordLog logger msg serviceLog = do
             , extra = "service" .= value
             }
 
-runLoggingT :: Logger -> ML.LoggingT IO () -> IO ()
+runLoggingT :: forall m a. Logger -> ML.LoggingT m a -> m a
 runLoggingT logger (ML.LoggingT run) = run (toLoggerIO logger)
 
 -- | Convert a 'Logger' to one that's compabible with monad-logger


### PR DESCRIPTION
`runLoggingT` の型制約を緩め、`IO ()` 以外にも使えるよう修正してみました。