### PR TITLE
recordLogを削除 etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----
+
+* recordLogを削除
+
 v0.2
 ----
 

--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -79,7 +79,6 @@ library
     , generic-data
     , monad-logger
     , mtl
-    , proto3-suite
     , raven-haskell ==0.1.4.*
     , resource-pool ^>= 0.3
     , safe-exceptions

--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -15,9 +15,9 @@ library
       Herp.Logger
       Herp.Logger.LogLevel
       Herp.Logger.Payload
-      Herp.Logger.SentryTransport
-      Herp.Logger.StdoutTransport
-      Herp.Logger.Transport
+      Herp.Logger.Transport.Sentry
+      Herp.Logger.Transport.Stdout
+      Herp.Logger.Transport.Types
       Herp.Logger.ANSI.Coloring
   hs-source-dirs:
       src

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -13,7 +13,6 @@ module Herp.Logger
     , defaultLoggerConfig
     , logM
     , logIO
-    , recordLog
     , urgentLog
     , Herp.Logger.flush
     -- * Payload
@@ -49,7 +48,6 @@ import "resource-pool" Data.Pool
 import "text" Data.Text.Encoding qualified as T
 import Data.UnixTime (formatUnixTime, fromEpochTime)
 import System.PosixCompat.Time (epochTime)
-import "proto3-suite" Proto3.Suite.JSONPB qualified as JSONPB
 
 import Herp.Logger.Payload           as P
 import Herp.Logger.LogLevel          as X
@@ -235,27 +233,6 @@ logM msg = do
 
 flush :: forall r m. (MonadReader r m, HasLogger r, MonadIO m) => m ()
 flush = asks toLogger >>= liftIO . loggerFlush
-
--- logging function for service log
-recordLog :: (MonadIO m, JSONPB.ToJSONPB serviceLog) => Logger -> Text -> serviceLog -> m ()
-recordLog logger msg serviceLog = do
-    let msgLevel = Informational -- datadogはloglevelを要求する
-    let Logger {push, timeCache} = logger
-    when (checkToLog logger msgLevel) $ do
-        let options =
-                JSONPB.jsonPBOptions
-                    { -- NOTE: BigQueryで扱いやすくするため、デフォルト値を省略せず、oneofは使わない
-                      JSONPB.optEmitDefaultValuedFields = True,
-                      JSONPB.optEmitNamedOneof = False
-                    }
-        let value = JSONPB.toJSONPB serviceLog options
-        date <- liftIO timeCache
-        liftIO $ push TransportInput {
-              level = msgLevel
-            , date = BS.toShort date
-            , message = msg
-            , extra = "service" .= value
-            }
 
 runLoggingT :: forall m a. Logger -> ML.LoggingT m a -> m a
 runLoggingT logger (ML.LoggingT run) = run (toLoggerIO logger)

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -51,8 +51,8 @@ import System.PosixCompat.Time (epochTime)
 
 import Herp.Logger.Payload           as P
 import Herp.Logger.LogLevel          as X
-import Herp.Logger.Transport         as X
-import Herp.Logger.StdoutTransport
+import Herp.Logger.Transport.Types   as X
+import Herp.Logger.Transport.Stdout  as X
 
 import "text" Data.Text as Text
 import "text" Data.Text.Encoding as Text

--- a/src/Herp/Logger/Transport/Sentry.hs
+++ b/src/Herp/Logger/Transport/Sentry.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Herp.Logger.SentryTransport
+module Herp.Logger.Transport.Sentry
     ( sentry
     ) where
 
@@ -18,7 +18,7 @@ import "raven-haskell" System.Log.Raven.Types
     )
 import "unordered-containers" Data.HashMap.Strict qualified as HashMap
 import Herp.Logger.LogLevel qualified as Level (LogLevel(..))
-import Herp.Logger.Transport (Transport(..), TransportInput(..))
+import Herp.Logger.Transport.Types (Transport(..), TransportInput(..))
 
 
 #if MIN_VERSION_aeson(2,0,0)

--- a/src/Herp/Logger/Transport/Stdout.hs
+++ b/src/Herp/Logger/Transport/Stdout.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE CPP #-}
 
-module Herp.Logger.StdoutTransport (
+module Herp.Logger.Transport.Stdout (
     stdoutTransport,
     stdoutANSITransport,
 ) where
 
 import Herp.Logger.LogLevel
-import Herp.Logger.Transport
+import Herp.Logger.Transport.Types
 import "fast-logger" System.Log.FastLogger (LoggerSet, ToLogStr (toLogStr), flushLogStr, pushLogStrLn)
 
 import "aeson" Data.Aeson ((.=))

--- a/src/Herp/Logger/Transport/Stdout.hs
+++ b/src/Herp/Logger/Transport/Stdout.hs
@@ -18,13 +18,9 @@ import Data.Text.Encoding qualified as T
 import Herp.Logger.ANSI.Coloring (coloringLogInfoStr)
 
 #if MIN_VERSION_aeson(2,0,0)
-import "aeson" Data.Aeson.Key (fromText)
 import "aeson" Data.Aeson.KeyMap as KM
 #else
 import Data.HashMap.Strict qualified as KM
-import Data.Text (Text)
-fromText :: Text -> Text
-fromText = id
 #endif
 
 stdoutTransport' :: Text -> (LoggerSet -> TransportInput -> IO ()) -> LoggerSet -> LogLevel -> Transport

--- a/src/Herp/Logger/Transport/Types.hs
+++ b/src/Herp/Logger/Transport/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PackageImports #-}
 
-module Herp.Logger.Transport
+module Herp.Logger.Transport.Types
     ( Transport(..)
     , TransportInput(..)
     ) where


### PR DESCRIPTION
ロガーのインターフェイスは統一したい・依存を減らしたいので、現状かなり浮いている `recordLog` 関数は削除した。代わりにアプリケーション側でToJSONPBを呼ぶようにしたい