### PR TITLE
Fix name of imported module in `tests/stdout.hs`

### DIFF
--- a/tests/stdout.hs
+++ b/tests/stdout.hs
@@ -8,7 +8,7 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (bracket)
 import Control.Monad.Reader
 import Herp.Logger as Logger
-import Herp.Logger.StdoutTransport
+import Herp.Logger.Transport.Stdout
 import System.Log.FastLogger.LoggerSet as LS
 
 loggerLevelTest config = do


### PR DESCRIPTION
こちらのPR (https://github.com/herp-inc/herp-logger/pull/25) でモジュール名の変更があったので、それを `tests/stdout.hs` にも反映させました。