### PR TITLE
Modify message format for `stdoutANSITransport`

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -80,6 +80,7 @@ library
     , monad-logger
     , mtl
     , raven-haskell ==0.1.4.*
+    , pretty-simple
     , resource-pool ^>= 0.3
     , safe-exceptions
     , stm

--- a/src/Herp/Logger/LogLevel.hs
+++ b/src/Herp/Logger/LogLevel.hs
@@ -9,12 +9,14 @@ module Herp.Logger.LogLevel
     ( LogLevel(..)
     , parseLogLevel
     , convertLogLevel
+    , convertLogLevelToStr
     ) where
 
 import "aeson"   Data.Aeson                     ( Value(String), ToJSON(..), FromJSON(..) )
 import "base"    GHC.OverloadedLabels           ( IsLabel(fromLabel) )
 import Control.Monad.Logger qualified as M
 import Data.Text (Text, toLower)
+import Data.String (IsString)
 
 -- | https://tools.ietf.org/html/rfc5424#section-6.2.1
 -- https://scrapbox.io/herp-inc/RFC_draft_%E3%83%AD%E3%82%B0%E3%83%AC%E3%83%99%E3%83%AB%E3%81%AB%E3%81%AF_syslog_%E5%BD%A2%E5%BC%8F%E3%82%92%E4%BD%BF%E3%81%86
@@ -60,15 +62,19 @@ parseLogLevel = \case
 instance FromJSON LogLevel where
     parseJSON obj = parseJSON obj >>= either fail pure . parseLogLevel
 
+convertLogLevelToStr :: (IsString a) => LogLevel -> a
+convertLogLevelToStr = \case
+    Emergency     -> "emerg"
+    Alert         -> "alert"
+    Critical      -> "crit"
+    Error         -> "error"
+    Warning       -> "warn"
+    Notice        -> "notice"
+    Informational -> "info"
+    Debug         -> "debug"
+
 instance ToJSON LogLevel where
-    toJSON Emergency     = String "emerg"
-    toJSON Alert         = String "alert"
-    toJSON Critical      = String "crit"
-    toJSON Error         = String "error"
-    toJSON Warning       = String "warn"
-    toJSON Notice        = String "notice"
-    toJSON Informational = String "info"
-    toJSON Debug         = String "debug"
+    toJSON = String . convertLogLevelToStr
 
 instance IsLabel "emerg" LogLevel where
     fromLabel = Emergency

--- a/src/Herp/Logger/Transport/Stdout.hs
+++ b/src/Herp/Logger/Transport/Stdout.hs
@@ -15,7 +15,8 @@ import "aeson" Data.Aeson.Encoding qualified as A
 import Data.ByteString.Short qualified as SB
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
-import Herp.Logger.ANSI.Coloring (coloringLogInfoStr)
+import Herp.Logger.ANSI.Coloring
+    ( convertTransportInputToFormattedMessageANSI )
 
 #if MIN_VERSION_aeson(2,0,0)
 import "aeson" Data.Aeson.KeyMap as KM
@@ -55,7 +56,6 @@ stdoutTransport = stdoutTransport' "stdout" push
 stdoutANSITransport :: LoggerSet -> LogLevel -> Transport
 stdoutANSITransport = stdoutTransport' "stdoutANSI" push
   where
-    push loggerSet input@TransportInput{level} =
-        let value = convertTransportInputToEncoding input
-            json = A.encodingToLazyByteString value
-         in pushLogStrLn loggerSet (toLogStr $ coloringLogInfoStr level json)
+    push loggerSet input =
+        let json = convertTransportInputToFormattedMessageANSI input
+         in pushLogStrLn loggerSet (toLogStr json)

--- a/tests/stdout.hs
+++ b/tests/stdout.hs
@@ -23,6 +23,8 @@ loggerLevelTest config = do
         logM [ #crit, "lorem ipsum" ]
         logM [ #alert, "lorem ipsum" ]
         logM [ #emerg, "lorem ipsum" ]
+        let msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis tortor enim, facilisis vitae ex non, molestie fringilla dui. Duis porta neque risus, eu iaculis odio semper quis. Cras suscipit molestie lacus, ac fringilla nulla blandit quis. Maecenas feugiat erat neque, id mattis nibh elementum sed. Donec nec felis nisi. Cras facilisis dui imperdiet velit rhoncus lobortis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Praesent eget lorem consequat, elementum sapien eu, rhoncus est. Etiam tincidunt leo nibh, a ullamcorper orci tincidunt id. Curabitur non dui ac ipsum eleifend iaculis ultrices at felis.\n\nAenean mauris metus, iaculis eget sagittis ut, fringilla nec nunc. Vivamus ante dolor, bibendum ut tellus gravida, ultricies bibendum mi. Morbi vel lectus pulvinar, accumsan leo eu, maximus ante. Morbi justo nisl, malesuada eu ex venenatis, bibendum aliquam arcu. In scelerisque elementum eros, id pretium libero eleifend ac. Quisque dictum, turpis a faucibus tempus, tellus leo ullamcorper libero, ac condimentum ex ante eu tortor. Sed sit amet dolor arcu."
+        logM [ #info, msg, "key" .= ("value" :: String) ]
 
     loggerCleanup logger
 


### PR DESCRIPTION
`stdoutANSITransport` のターミナルに出力する文字列を整形し、見やすい形に変更しました。これに伴い、改行を含むメッセージが複数行に渡り表示されるようになります。またこれらの変更を確認するために、改行を含むメッセージを出力するログ関数をテストに追記しました。
![stdoutANSITransport](https://user-images.githubusercontent.com/103056244/198973782-3dc14409-58d4-4a2c-b08e-b3785b36fc83.png)
