### PR TITLE
flushの挙動の改善・テストの導入etc

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -91,18 +91,18 @@ library
   default-language: Haskell2010
 
 common test
+  ghc-options: -Wall -Wcompat -Wunused-packages
   hs-source-dirs:
       tests
   build-depends:
       base >=4.7 && <5
     , herp-logger
-    , fast-logger
-    , mtl
   default-language: Haskell2010
 
 test-suite stdout
   import: test
   main-is: stdout.hs
+  build-depends: fast-logger, mtl
 
 test-suite abort
   import: test

--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 
 -- This file has been generated from package.yaml by hpack version 0.34.5.
 --
@@ -90,9 +90,7 @@ library
     , unordered-containers
   default-language: Haskell2010
 
-test-suite stdout
-  type: exitcode-stdio-1.0
-  main-is: stdout.hs
+common test
   hs-source-dirs:
       tests
   build-depends:
@@ -101,3 +99,12 @@ test-suite stdout
     , fast-logger
     , mtl
   default-language: Haskell2010
+
+test-suite stdout
+  import: test
+  main-is: stdout.hs
+
+test-suite abort
+  import: test
+  main-is: abort.hs
+  

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -10,6 +10,7 @@ module Herp.Logger
     , LogLevel(..)
     , LoggerConfig(..)
     , newLogger
+    , withLogger
     , defaultLoggerConfig
     , logM
     , logOtherM
@@ -142,6 +143,9 @@ defaultLoggerConfig =
         , concurrencyLevel = 1
         , logLevel = Debug
         }
+
+withLogger :: LoggerConfig -> (Logger -> IO a) -> IO a
+withLogger config = E.bracket (newLogger config) loggerCleanup
 
 newLogger :: LoggerConfig -> IO Logger
 newLogger LoggerConfig{..} = do

--- a/tests/abort.hs
+++ b/tests/abort.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Monad
+import Herp.Logger as Logger
+import System.Environment
+
+run :: Bool -> Bool -> IO ()
+run doFlush doCleanup = do
+    logger <- newLogger defaultLoggerConfig
+    logIO logger [ #info, "before flush", "doFlush" .= doFlush, "doCleanup" .= doCleanup ]
+    when doFlush $ loggerFlush logger
+    logIO logger [ #warn, "after flush", "doFlush" .= doFlush, "doCleanup" .= doCleanup ]
+    when doCleanup $ loggerCleanup logger
+
+main :: IO ()
+main = getArgs >>= \case
+    ["flush"] -> run True False
+    ["cleanup"] -> run False True
+    _ -> run False False

--- a/tests/stdout.hs
+++ b/tests/stdout.hs
@@ -4,16 +4,14 @@
 
 module Main where
 
-import Control.Concurrent (threadDelay)
 import Control.Exception (bracket)
 import Control.Monad.Reader
 import Herp.Logger as Logger
 import Herp.Logger.Transport.Stdout
 import System.Log.FastLogger.LoggerSet as LS
 
-loggerLevelTest config = do
-    logger <- Logger.newLogger config
-
+loggerLevelTest :: LoggerConfig -> IO ()
+loggerLevelTest config = withLogger config $ \logger -> do
     flip runReaderT logger $ do
         logM [ #debug, "debug" ]
         logM [ #info, "hello, world", "key" .= ("value" :: String) ]
@@ -25,8 +23,6 @@ loggerLevelTest config = do
         logM [ #emerg, "lorem ipsum" ]
         let msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis tortor enim, facilisis vitae ex non, molestie fringilla dui. Duis porta neque risus, eu iaculis odio semper quis. Cras suscipit molestie lacus, ac fringilla nulla blandit quis. Maecenas feugiat erat neque, id mattis nibh elementum sed. Donec nec felis nisi. Cras facilisis dui imperdiet velit rhoncus lobortis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Praesent eget lorem consequat, elementum sapien eu, rhoncus est. Etiam tincidunt leo nibh, a ullamcorper orci tincidunt id. Curabitur non dui ac ipsum eleifend iaculis ultrices at felis.\n\nAenean mauris metus, iaculis eget sagittis ut, fringilla nec nunc. Vivamus ante dolor, bibendum ut tellus gravida, ultricies bibendum mi. Morbi vel lectus pulvinar, accumsan leo eu, maximus ante. Morbi justo nisl, malesuada eu ex venenatis, bibendum aliquam arcu. In scelerisque elementum eros, id pretium libero eleifend ac. Quisque dictum, turpis a faucibus tempus, tellus leo ullamcorper libero, ac condimentum ex ante eu tortor. Sed sit amet dolor arcu."
         logM [ #info, msg, "key" .= ("value" :: String) ]
-
-    loggerCleanup logger
 
 main :: IO ()
 main = bracket (LS.newStdoutLoggerSet 4096) LS.rmLoggerSet $ \loggerSet -> do


### PR DESCRIPTION
* flushを呼び出すとLoggerSetのflushが呼ばれるが、キューに積まれている書き込み処理に影響を及ぼさないため扱いにくい挙動である。flushを呼ぶとresource-poolの中を一旦流すようにする