### PR TITLE
Use a patched resource-pool to specify num of stripes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .stack-work
+dist-newstyle/
+cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages:
+    .
+
+source-repository-package
+    type: git
+    location: https://github.com/MercuryTechnologies/pool.git
+    tag: 1aa551e41e3527ce23f38251567507df5357fdb9
+

--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.8
+cabal-version: 3.6
 
 -- This file has been generated from package.yaml by hpack version 0.34.5.
 --
@@ -101,10 +101,11 @@ common test
 
 test-suite stdout
   import: test
+  type: exitcode-stdio-1.0
   main-is: stdout.hs
   build-depends: fast-logger, mtl
 
 test-suite abort
   import: test
+  type: exitcode-stdio-1.0
   main-is: abort.hs
-  

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -88,6 +88,7 @@ mkThreadPool poolMaxResources errHandler = do
             atomically (flushTQueue queue) >>= sequence_
             cancel thread
     let poolCacheTTL = 3600
+    let poolNumStripes = Just 1
     pool <- newPool PoolConfig{..}
     pure pool
 


### PR DESCRIPTION
resource-pool-0.3 はmaxResourceを超えてリソースを確保する問題がある(https://github.com/scrive/pool/issues/13) ため、その修正PRを取り込む。
