### PR TITLE
Add `convertLogLevelToML`

### DIFF
--- a/src/Herp/Logger/LogLevel.hs
+++ b/src/Herp/Logger/LogLevel.hs
@@ -9,6 +9,7 @@ module Herp.Logger.LogLevel
     ( LogLevel(..)
     , parseLogLevel
     , convertLogLevel
+    , convertLogLevelToML
     , convertLogLevelToStr
     ) where
 
@@ -46,6 +47,16 @@ convertLogLevel = \case
     M.LevelOther (toLower -> "alert") -> Right Alert
     M.LevelOther (toLower -> "emergency") -> Right Emergency
     M.LevelOther level -> Left level
+
+-- | Convert 'LogLevel' to 'M.LogLevel'.
+convertLogLevelToML :: LogLevel -> M.LogLevel
+convertLogLevelToML = \case
+    Debug -> M.LevelDebug
+    Informational -> M.LevelInfo
+    Notice -> M.LevelInfo
+    Warning -> M.LevelWarn
+    Error -> M.LevelError
+    level -> M.LevelOther (convertLogLevelToStr level)
 
 parseLogLevel :: String -> Either String LogLevel
 parseLogLevel = \case


### PR DESCRIPTION
herp-loggerのLogLevelからmonad-loggerのLogLevelに変換する`convertLogLevelToML`関数を追加しました。この関数を使うことにより、monad-loggerのLogLevelを受け取る関数にherp-loggerのLogLevelを適用することが出来るようになります。