### PR TITLE
TransportをVectorで持つようにする

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -85,6 +85,7 @@ library
     , text
     , unix-compat
     , unix-time
+    , vector
   default-language: Haskell2010
 
 common test

--- a/src/Herp/Logger.hs
+++ b/src/Herp/Logger.hs
@@ -61,6 +61,7 @@ import "resource-pool" Data.Pool
 import "text" Data.Text.Encoding qualified as T
 import Data.UnixTime (formatUnixTime, fromEpochTime)
 import System.PosixCompat.Time (epochTime)
+import "vector" Data.Vector (Vector)
 
 import Herp.Logger.Payload           as P
 import Herp.Logger.LogLevel          as X
@@ -105,7 +106,7 @@ runTask thPool param = withResource thPool $ \ (ch, _th) -> atomically (writeTQu
 
 data Logger = Logger
     { loggerThresholdLevel :: LogLevel
-    , transports :: [Transport]
+    , transports :: Vector Transport
     , timeCache :: IO FormattedTime
     , push :: TransportInput -> IO ()
     , loggerCleanup :: IO ()
@@ -130,7 +131,7 @@ urgentLog msgLevel msg extra = do
     BC.putStrLn $ A.encodingToLazyByteString $ A.pairs $ series <> extra
 
 data LoggerConfig = LoggerConfig
-    { createTransports :: IO [Transport]
+    { createTransports :: IO (Vector Transport)
     , concurrencyLevel :: ConcurrencyLevel
     , logLevel :: LogLevel
     }


### PR DESCRIPTION
# 概要

taglake (release-20230306-0)でプロファイルを取ったところ、logger周りのメモリ使用量が増加しがちだった(ちなみにこれはherp-loggerがresource-pool 0.4対応する前の結果ですが、resource-pool 0.4を使うようにしても同じような結果になります):
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/96223955/227077088-463393d8-32c5-4910-8409-405805293c8f.png">

そこで、`createTransports`と`transports`をリストから`Vector`にしたところ、logger周りのメモリ使用量が改善された雰囲気が出てきた:
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/96223955/227077550-e53ad4b8-11a2-4d94-b168-f3c008deb2d9.png">

taglake release-20230306-0は`createTransports`の要素数が１なので、なぜこれで改善されるのかはよく分かっていません