### PR TITLE
aeson-1.5 互換を CPP で対応

### DIFF
--- a/herp-logger.cabal
+++ b/herp-logger.cabal
@@ -68,7 +68,7 @@ library
       InstanceSigs
       ImportQualifiedPost
   build-depends:
-      aeson ^>= 2.2
+      aeson >= 1.5 && < 2.3
     , ansi-terminal
     , async
     , base >=4.7 && <5
@@ -86,6 +86,9 @@ library
     , unix-compat
     , unix-time
     , vector
+
+      -- this is requrired by aeson < 2.0
+    , unordered-containers
   default-language: Haskell2010
 
 common test

--- a/src/Herp/Logger/Payload.hs
+++ b/src/Herp/Logger/Payload.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Herp.Logger.Payload
@@ -14,7 +15,7 @@ module Herp.Logger.Payload
   ) where
 
 import Control.Exception
-import Data.Aeson (Object, KeyValue(..), Value)
+import Data.Aeson (Object, KeyValue(..))
 import Data.ByteString (ByteString)
 import Data.ByteString.Builder qualified as BB
 import Data.ByteString.Lazy qualified as BL
@@ -27,6 +28,10 @@ import Generic.Data
 import GHC.Exts
 import GHC.OverloadedLabels
 import Herp.Logger.LogLevel
+
+#if MIN_VERSION_aeson(2,2,0)
+import Data.Aeson (Value)
+#endif
 
 data Payload = Payload
   { payloadLevel :: Max LogLevel
@@ -80,6 +85,11 @@ object obj = mempty { payloadObject = obj }
 instance IsString Payload where
   fromString = message . fromString
 
+#if MIN_VERSION_aeson(2,2,0)
 instance KeyValue Value Payload where
   key .= val = mempty { payloadObject = key .= val }
   explicitToField f k v = mempty { payloadObject = k .= f v }
+#else
+instance KeyValue Payload where
+  key .= val = mempty { payloadObject = key .= val }
+#endif


### PR DESCRIPTION
「proto3-suite が aeson < 2.2 を要求するため、一緒に利用できない」問題に対応する。